### PR TITLE
Landing page to job posting page routing

### DIFF
--- a/launchpad-frontend/src/index.js
+++ b/launchpad-frontend/src/index.js
@@ -16,7 +16,7 @@ export const pages = {
   landing: "/landing",
   notifications: "/notifications",
   applications: "/applications",
-  jobs: "/jobs/:jobId",
+  jobs: "/jobs",
   account: "/account",
   settings: "/settings",
 };
@@ -41,7 +41,8 @@ function Pages({ userId, setUserId }) {
             element={<NotificationsPage userId={userId} />}
           />
           <Route path={pages.applications} element={<MyApplication />} />
-          <Route path={pages.jobs} element={<JobPostings setPage={setPage}/>} />
+          <Route path={pages.jobs} element={<JobPostings setPage={setPage} />} />
+          <Route path={`${pages.jobs}/:jobId`} element={<JobPostings setPage={setPage} />} />
           <Route path={pages.account} element={<AccountSettings userId={userId}/>} />
           <Route path={pages.settings} element={<App />} />
         </Routes>

--- a/launchpad-frontend/src/index.js
+++ b/launchpad-frontend/src/index.js
@@ -16,7 +16,7 @@ export const pages = {
   landing: "/landing",
   notifications: "/notifications",
   applications: "/applications",
-  jobs: "/jobs",
+  jobs: "/jobs/:jobId",
   account: "/account",
   settings: "/settings",
 };
@@ -34,14 +34,14 @@ function Pages({ userId, setUserId }) {
         <Routes>
           <Route
             path={pages.landing}
-            element={<LandingPage userId={userId} />}
+            element={<LandingPage userId={userId} setPage={setPage} />}
           />
           <Route
             path={pages.notifications}
             element={<NotificationsPage userId={userId} />}
           />
           <Route path={pages.applications} element={<MyApplication />} />
-          <Route path={pages.jobs} element={<JobPostings />} />
+          <Route path={pages.jobs} element={<JobPostings setPage={setPage}/>} />
           <Route path={pages.account} element={<AccountSettings userId={userId}/>} />
           <Route path={pages.settings} element={<App />} />
         </Routes>

--- a/launchpad-frontend/src/jobsPage/jobsPage.js
+++ b/launchpad-frontend/src/jobsPage/jobsPage.js
@@ -19,8 +19,9 @@ import { ClockIcon, PinIcon, LaptopIcon } from "../components/jobsIcons";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import CloseIcon from "@mui/icons-material/Close";
 import { ApplyButton } from "../components/applicationPopUp";
+import { useParams, useNavigate } from 'react-router-dom';
 
-export function JobPostings() {
+export function JobPostings({setPage}) {
   const [value, setValue] = React.useState(0);
   const [searchValue, setSearchValue] = React.useState("");
   const [typeFilter, setTypeFilter] = React.useState(null);
@@ -29,6 +30,8 @@ export function JobPostings() {
   const [jobsData, setJobsData] = React.useState({});
   const [companyData, setCompanyData] = React.useState({});
   const [userData, setUserData] = React.useState({});
+  const { jobId } = useParams();
+  const navigate = useNavigate();
 
   useEffect(() => {
     fetch(
@@ -56,6 +59,11 @@ export function JobPostings() {
         setUserData(data);
       });
   }, []);
+
+  const clickedTab= () => {
+    setPage('/jobs/:jobId');
+    navigate(`/jobs/:jobId`);
+  }
 
   const jobsCompanyData =
     jobsData.data && companyData.data && userData.data
@@ -121,19 +129,21 @@ export function JobPostings() {
         <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
           <ThemeProvider theme={theme}>
             <Tabs value={value} onChange={handleChange}>
-              <Tab label="Postings" {...a11yProps(0)} />
-              <Tab label="Saved" {...a11yProps(1)} />
+              <Tab label="Postings" {...a11yProps(0)} onClick={clickedTab} />
+              <Tab label="Saved" {...a11yProps(1)} onClick={clickedTab}/>
             </Tabs>
           </ThemeProvider>
         </Box>
         <CustomTabPanel value={value} index={0}>
-          <Postings searchValue={searchValue} postings={jobsCompanyData} />
+          <Postings searchValue={searchValue} postings={jobsCompanyData} jobId={jobId} setPage={setPage}/>
         </CustomTabPanel>
         <CustomTabPanel value={value} index={1}>
           <Postings
             saved
             searchValue={searchValue}
             postings={jobsCompanyData}
+            jobId={jobId}
+            setPage={setPage}
           />
         </CustomTabPanel>
       </Box>
@@ -203,7 +213,8 @@ function CustomTabPanel(props) {
   );
 }
 
-function Postings({ saved, searchValue, postings }) {
+function Postings({ saved, searchValue, postings, jobId, setPage }) {
+  const navigate = useNavigate();
   const [postingsExpanded, setPostingsExpanded] = React.useState(false);
 
   const savedPostings = postings.filter((row) => row.saved);
@@ -214,28 +225,29 @@ function Postings({ saved, searchValue, postings }) {
       row.companyName.toLowerCase().includes(searchValue.toLowerCase())
   );
 
-  const [postingSelected, setPostingSelected] = React.useState(
-    saved
-      ? savedPostings.length > 0
-        ? savedPostings[0].postingId
-        : null
-      : filteredPostings.length > 0
-      ? filteredPostings[0].postingId
-      : null
-  );
-
+  const [postingSelected, setPostingSelected] = React.useState(null);
+  
   const selectedPosting = filteredPostings.find(
     (row) => row.postingId === postingSelected
   );
 
+  // select job posting if Id provided
   useEffect(() => {
-    if (selectedPosting === undefined) {
+    if(jobId !== undefined){
+      setPostingSelected(parseInt(jobId));
+    }
+    else if (selectedPosting === undefined) {
       setPostingSelected(null);
     }
-  }, [selectedPosting]);
+  }, [selectedPosting, jobId]);
 
   const [, updateState] = React.useState();
   const forceUpdate = React.useCallback(() => updateState({}), []);
+
+  const clickedJob = (jobId) => {
+    setPage('/jobs/:jobId');
+    navigate(`/jobs/${jobId}`);
+  }
 
   return (
     <Grid container spacing={6}>
@@ -251,7 +263,7 @@ function Postings({ saved, searchValue, postings }) {
                     <TableRow
                       key={i}
                       sx={PageStyles.tableRow}
-                      onClick={() => setPostingSelected(row.postingId)}
+                      onClick={() => clickedJob(row.postingId)}
                       selected={postingSelected === row.postingId}
                     >
                       <TableCell component="th" scope="row" align="center">

--- a/launchpad-frontend/src/jobsPage/jobsPage.js
+++ b/launchpad-frontend/src/jobsPage/jobsPage.js
@@ -61,8 +61,8 @@ export function JobPostings({setPage}) {
   }, []);
 
   const clickedTab= () => {
-    setPage('/jobs/:jobId');
-    navigate(`/jobs/:jobId`);
+    setPage('/jobs');
+    navigate(`/jobs`);
   }
 
   const jobsCompanyData =

--- a/launchpad-frontend/src/jobsPage/jobsPage.js
+++ b/launchpad-frontend/src/jobsPage/jobsPage.js
@@ -245,7 +245,7 @@ function Postings({ saved, searchValue, postings, jobId, setPage }) {
   const forceUpdate = React.useCallback(() => updateState({}), []);
 
   const clickedJob = (jobId) => {
-    setPage('/jobs/:jobId');
+    setPage(`/jobs/${jobId}`);
     navigate(`/jobs/${jobId}`);
   }
 

--- a/launchpad-frontend/src/landingPage/landingPage.js
+++ b/launchpad-frontend/src/landingPage/landingPage.js
@@ -43,7 +43,7 @@ export function LandingPage({ userId, setPage }) {
   }
 
   const clickedJob = (jobId) => {
-    setPage('/jobs/:jobId');
+    setPage(`/jobs/${jobId}`);
     navigate(`/jobs/${jobId}`);
   }
 

--- a/launchpad-frontend/src/landingPage/landingPage.js
+++ b/launchpad-frontend/src/landingPage/landingPage.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Grid, IconButton } from "@mui/material";
 import { mock_data } from "./mockData";
+import { useNavigate } from "react-router-dom";
 import "./landingPage.css";
 import { SubmittedIcon, ViewedIcon } from "../components/landingIcons";
 import Table from "@mui/material/Table";
@@ -18,13 +19,13 @@ function StatusIcon(status) {
   }
 }
 
-export function LandingPage({ userId }) {
+export function LandingPage({ userId, setPage }) {
   const [data, setData] = useState(mock_data);
   const [appsExpanded, setAppsExpanded] = useState(false);
   const [savedExpanded, setSavedExpanded] = useState(false);
   const { applications, saved_jobs, recommended } = data;
   const [userData, setUserData] = useState(null);
-
+  const navigate = useNavigate();
   useEffect(() => {
     if (userId) {
       fetch(`/users/${userId}`)
@@ -39,6 +40,11 @@ export function LandingPage({ userId }) {
     let temp = { ...data };
     temp.recommended[i].saved = !temp.recommended[i].saved;
     setData(temp);
+  }
+
+  const clickedJob = (jobId) => {
+    setPage('/jobs/:jobId');
+    navigate(`/jobs/${jobId}`);
   }
 
   if (!userId) {
@@ -59,7 +65,7 @@ export function LandingPage({ userId }) {
                 {applications
                   .slice(0, appsExpanded ? applications.length : 3)
                   .map((row, i) => (
-                    <TableRow key={i} sx={PageStyles.tableRow}>
+                    <TableRow key={i} sx={PageStyles.tableRow} onClick={() => {clickedJob(row.postingId)}}>
                       <TableCell
                         component="th"
                         scope="row"
@@ -107,7 +113,7 @@ export function LandingPage({ userId }) {
                 {saved_jobs
                   .slice(0, savedExpanded ? saved_jobs.length : 3)
                   .map((row, i) => (
-                    <TableRow key={i} sx={PageStyles.tableRow}>
+                    <TableRow key={i} sx={PageStyles.tableRow} onClick={() => {clickedJob(row.postingId)}}>
                       <TableCell
                         component="th"
                         scope="row"
@@ -152,7 +158,7 @@ export function LandingPage({ userId }) {
             <Table aria-label="simple table" style={PageStyles.table}>
               <TableBody>
                 {recommended.slice(0, 6).map((row, i) => (
-                  <TableRow key={i} sx={PageStyles.tableRow}>
+                  <TableRow key={i} sx={PageStyles.tableRow} onClick={() => {clickedJob(row.postingId)}}>
                     <TableCell style={{ paddingLeft: 30, paddingRight: 20 }}>
                       <p style={PageStyles.job_title}>{row.title}</p>
                       <p style={PageStyles.company}>{row.company}</p>

--- a/launchpad-frontend/src/landingPage/mockData.js
+++ b/launchpad-frontend/src/landingPage/mockData.js
@@ -2,6 +2,7 @@ const first_name = "LaunchPad Larry";
 
 const apps = [
   {
+    postingId: 1,
     title: "Software Developer, Intern",
     company: "Apple",
     type: "4-month Internship",
@@ -10,6 +11,7 @@ const apps = [
     logo: "https://www.edigitalagency.com.au/wp-content/uploads/apple-logo-png-black.png",
   },
   {
+    postingId: 2,
     title: "Software Developer, Intern",
     company: "Scotiabank",
     type: "4-month Internship",
@@ -18,6 +20,7 @@ const apps = [
     logo: "https://seeklogo.com/images/S/scotiabank-logo-D2F1AF87B5-seeklogo.com.png",
   },
   {
+    postingId: 3,
     title: "Software Developer, Intern",
     company: "Apple",
     type: "4-month Internship",
@@ -26,6 +29,7 @@ const apps = [
     logo: "https://www.edigitalagency.com.au/wp-content/uploads/apple-logo-png-black.png",
   },
   {
+    postingId: 4,
     title: "Software Developer, Intern",
     company: "Apple",
     type: "4-month Internship",
@@ -37,6 +41,7 @@ const apps = [
 
 const saved = [
   {
+    postingId: 1,
     title: "Software Developer, Intern",
     company: "Apple",
     type: "4-month Internship",
@@ -44,6 +49,7 @@ const saved = [
     logo: "https://www.edigitalagency.com.au/wp-content/uploads/apple-logo-png-black.png",
   },
   {
+    postingId: 2,
     title: "Software Developer, Intern",
     company: "Apple",
     type: "4-month Internship",
@@ -51,6 +57,7 @@ const saved = [
     logo: "https://www.edigitalagency.com.au/wp-content/uploads/apple-logo-png-black.png",
   },
   {
+    postingId: 3,
     title: "Software Developer, Intern",
     company: "Apple",
     type: "4-month Internship",
@@ -58,6 +65,7 @@ const saved = [
     logo: "https://www.edigitalagency.com.au/wp-content/uploads/apple-logo-png-black.png",
   },
   {
+    postingId: 4,
     title: "Software Developer, Intern",
     company: "Apple",
     type: "4-month Internship",
@@ -68,6 +76,7 @@ const saved = [
 
 const recs = [
   {
+    postingId: 1,
     title: "Software Developer, Intern",
     company: "Apple",
     type: "4-month Internship",
@@ -75,6 +84,7 @@ const recs = [
     saved: true,
   },
   {
+    postingId: 2,
     title: "Software Developer, Intern",
     company: "Apple",
     type: "4-month Internship",
@@ -82,6 +92,7 @@ const recs = [
     saved: false,
   },
   {
+    postingId: 3,
     title: "Software Developer, Intern",
     company: "Apple",
     type: "4-month Internship",
@@ -89,6 +100,7 @@ const recs = [
     saved: true,
   },
   {
+    postingId: 4,
     title: "Software Developer, Intern",
     company: "Apple",
     type: "4-month Internship",
@@ -96,6 +108,7 @@ const recs = [
     saved: true,
   },
   {
+    postingId: 5,
     title: "Software Developer, Intern",
     company: "Apple",
     type: "4-month Internship",
@@ -103,6 +116,7 @@ const recs = [
     saved: true,
   },
   {
+    postingId: 1,
     title: "Software Developer, Intern",
     company: "Apple",
     type: "4-month Internship",

--- a/launchpad-frontend/src/navigation.js
+++ b/launchpad-frontend/src/navigation.js
@@ -27,6 +27,8 @@ import { ThemeProvider, createTheme } from "@mui/material/styles";
 import { Link } from "react-router-dom";
 
 export function NavItems({ open, page, setPage, setShowLogout }) {
+  const isJobsPage = page.startsWith(`/jobs`);
+
   return (
     <React.Fragment>
       <ThemeProvider theme={theme}>
@@ -76,7 +78,7 @@ export function NavItems({ open, page, setPage, setShowLogout }) {
           <ListItemButton
             sx={NavStyles.navOption}
             onClick={useCallback(() => setPage(pages.jobs), [setPage])}
-            selected={page === pages.jobs}
+            selected={isJobsPage}
           >
             <LPListItemIcon open={open}>
               <JobIcon />


### PR DESCRIPTION
**Changes**
1)  Route user from the landing page to the selected job on the job posting page
2) Add dynamic job route /jobs/:jobId to the index.js page
3) Add job posting id to mockdata.js in the landing page to mock db 
4) Changed the job posting page state so that it selects no jobs (null) by default 

**Note:** the landing page is not connected to the db (that's a part of another ticket). As a result, when you click on the job posting id, it will not map to the db example. The mock data is mapping the static job posting to a random job posting in the db.

Currently, on the application table the first apple posting is being map to id 1 which is the Microsoft Software Engineering - Fulltime Opportunities for University Graduates posting, Scotiabank job posting is being map to id 2 which is the Microsoft Software Engineering: Intern Opportunities for University Students, Bay Area posting, etc. 

**Expected routing** 
![image](https://github.com/zafrinn/CPS714-project/assets/59449776/eebc8d04-2e1c-42af-afd9-02bf3e4fc38d)
pictures above clicks on Scotiabank and maps to the second Microsoft picture below
![image](https://github.com/zafrinn/CPS714-project/assets/59449776/1d35d03c-65fe-400d-892d-2aa85c4bff26)


**Expected default output**
![image](https://github.com/zafrinn/CPS714-project/assets/59449776/8554a640-8afd-43a4-8add-ad34bf64c4cd)

**Expected output when job selected**
![image](https://github.com/zafrinn/CPS714-project/assets/59449776/cf33161e-acc0-4014-949a-625525925779)

**Expected output with no selected job posting**
![image](https://github.com/zafrinn/CPS714-project/assets/59449776/1e81511b-1059-44f5-9344-eed24f388116)



